### PR TITLE
Filter for auth form field before finding auth token.

### DIFF
--- a/login.go
+++ b/login.go
@@ -174,7 +174,12 @@ func (c *client) initiateAuth0(clusterID, clientID string) (string, error) {
 		return "", err
 	}
 
-	csrf, found := doc.Find(`input[name="authenticity_token"]`).Attr("value")
+	authFormDoc := doc.Find(".auth-form")
+	if authFormDoc.Size() == 0 {
+		return "", errors.New("Unable to find auth form")
+	}
+
+	csrf, found := authFormDoc.Find(`input[name="authenticity_token"]`).Attr("value")
 	if !found {
 		return "", errors.New("Unable to extract CSRF token from response")
 	}


### PR DESCRIPTION
Thanks to net neutrality, there are now two fields on the github session page which have an authenticity_token field. This ensures that the field we are grabbing is part of the auth form.